### PR TITLE
playbooks for ELK stack

### DIFF
--- a/elasticstack.yml
+++ b/elasticstack.yml
@@ -1,0 +1,8 @@
+---
+- hosts: elk
+  become: yes
+  gather_facts: no
+  roles:
+  - elasticsearch
+  - logstash
+  - kibana

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -1,0 +1,5 @@
+- hosts: app
+  become: yes
+  gather_facts: no
+  roles:
+  - filebeat

--- a/files/elasticsearch.yml
+++ b/files/elasticsearch.yml
@@ -1,0 +1,4 @@
+cluster.name: elasticsearch-cluster
+node.name: node1
+discovery.type: single-node
+network.host: 0.0.0.0

--- a/files/filebeat.yml
+++ b/files/filebeat.yml
@@ -1,0 +1,23 @@
+filebeat:
+  inputs:
+    - type: log
+      json:
+        message_key: message
+      # let filebeat read linked log from host
+      paths:
+        - /var/log/app.log
+        
+setup:
+  kibana:
+    host: "http://kibana:5601"
+
+output:
+  logstash:
+    enabled: true
+    hosts: 
+      - logstash:5044
+
+# output:
+#   elasticsearch:
+#     hosts: ["http://elasticsearch:9200"]
+#     bulk_max_size: 1

--- a/files/pipeline/logstash.conf
+++ b/files/pipeline/logstash.conf
@@ -1,0 +1,27 @@
+input {
+	beats {
+		port => 5044
+    ssl  => false
+	}
+
+	tcp {
+		port => 5000
+	}
+}
+
+
+filter {
+ mutate {
+  #  gsub => ["json.msg", "([\w\d]+-)+[\w\d]+", "12345678"]
+  replace => { "message" => "test message" }
+
+ }
+}
+
+
+output {
+	elasticsearch {
+		hosts => "http://elasticsearch:9200"
+	}
+}
+

--- a/hosts
+++ b/hosts
@@ -14,6 +14,10 @@
 
 104.248.36.238
 
+[elk]
+
+104.248.36.238
+
 [all:vars]
 
 ansible_user=deploy

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: pull image on remote
+  become: yes
+  docker_image:
+    name: docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0
+    source: pull
+    # force_source: yes
+
+- name: ensure config directory is created
+  file:
+    path: /usr/share/elasticsearch/config
+    state: directory
+
+- name: ensure config is uploaded
+  copy:
+    src: elasticsearch.yml
+    dest: /usr/share/elasticsearch/config/elasticsearch.yml
+
+- name: run docker container
+  become: yes
+  docker_container:
+    name: elasticsearch
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.8.0
+    # network_mode: host
+    detach: yes
+    auto_remove: no
+    ports:
+      - "9200:9200"
+    volumes:
+      - /usr/share/elasticsearch/data:/usr/share/elasticsearch/data
+      - /usr/share/elasticsearch/config/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
+    restart_policy: on-failure
+    restart_retries: 10
+    state: started

--- a/roles/filebeat/tasks/main.yml
+++ b/roles/filebeat/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+- name: pull image on remote
+  become: yes
+  docker_image:
+    name: docker.elastic.co/beats/filebeat-oss:7.8.0
+    source: pull
+
+- name: ensure config directory is created
+  file:
+    path: /usr/share/filebeat/data
+    state: directory
+
+- name: ensure config is uploaded
+  copy:
+    src: filebeat.yml
+    dest: /usr/share/filebeat/filebeat.yml
+
+- name: run docker container
+  become: yes
+  docker_container:
+    name: filebeat
+    image: docker.elastic.co/beats/filebeat-oss:7.8.0
+    detach: yes
+    auto_remove: no
+
+    volumes:
+      - /usr/share/filebeat/data:/usr/share/filebeat/data
+      - /usr/share/filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      # link log form host directory to filebeat container
+      - /var/log/app.log:/var/log/app.log:ro
+    restart_policy: on-failure
+    restart_retries: 10
+    state: started

--- a/roles/kibana/tasks/main.yml
+++ b/roles/kibana/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: pull image on remote
+  become: yes
+  docker_image:
+    name: docker.elastic.co/kibana/kibana-oss:7.8.0
+    source: pull
+
+- name: run docker container
+  become: yes
+  environment:
+      ELASTICSEARCH_HOSTS: http://elasticsearch:9200
+  docker_container:
+    name: kibana
+    image: docker.elastic.co/kibana/kibana-oss:7.8.0
+    detach: yes
+    auto_remove: no
+    ports:
+      - "5601:5601"
+    restart_policy: on-failure
+    restart_retries: 10
+    state: started

--- a/roles/logstash/tasks/main.yml
+++ b/roles/logstash/tasks/main.yml
@@ -1,0 +1,34 @@
+---
+- name: pull image on remote
+  become: yes
+  docker_image:
+    name: docker.elastic.co/logstash/logstash-oss:7.8.0
+    source: pull
+
+- name: ensure config directory is created
+  file:
+    path: /usr/share/logstash/pipeline
+    state: directory
+
+- name: ensure config is uploaded
+  copy:
+    src: pipeline
+    dest: /usr/share/logstash/pipeline
+
+- name: run docker container
+  become: yes
+  docker_container:
+    name: logstash
+    image: docker.elastic.co/logstash/logstash-oss:7.8.0
+    detach: yes
+    auto_remove: no
+    ports:
+      - "5044:5044"
+      - "5000:5000/tcp"
+      - "5000:5000/udp"
+      - "9600:9600"
+    volumes:
+      - /usr/share/logstash/pipeline:/usr/share/logstash/pipeline:ro
+    restart_policy: on-failure
+    restart_retries: 10
+    state: started


### PR DESCRIPTION
Напишите плэйбуки для деплоя Elastic Stack. Сконфигурируйте Filebeat таким образом, чтобы он собирал логи из Docker контейнеров вместо файлов